### PR TITLE
Handle multiple options with same name correctly

### DIFF
--- a/templates/interfaces.erb
+++ b/templates/interfaces.erb
@@ -22,6 +22,12 @@ mapping <%= name_and_options[0] %>
 <% interfaces.sort.each do |name_and_options| %>
 iface <%= name_and_options[0] %> inet <%= name_and_options[1]["method"] %>
   <%- name_and_options[1].reject { |k, v| k == "method" }.sort.each do |option| -%>
+  <%- if option[1].is_a? Array -%>
+  <%- option[1].each do |value| -%>
+  <%= option[0] %> <%= value %>
+  <%- end -%>
+  <%- else -%>
   <%= option[0] %> <%= option[1] %>
+  <%- end -%>
   <%- end -%>
 <% end %>


### PR DESCRIPTION
If the interface should have several entries with the same name, only the last one in the hash made it into the config file. This change enables the value to be an array which is then expanded to multiple lines. Now one can write

```
'up' => [ 'ip route add 10.0.0.0/8 via 10.0.0.1', 'ip route add 192.168.0.0/16 via 10.0.0.1' ]
```

and have multiple up commands in the interface.
