### PR TITLE
Factor out restart and interface file generation

### DIFF
--- a/manifests/interface_file.pp
+++ b/manifests/interface_file.pp
@@ -1,0 +1,18 @@
+define network::interface_file(
+  $interfaces = {},
+  $mappings = {},
+  $auto = {},
+  $restart = false,
+  $file_pattern = '%s',
+){
+  include network::restart
+
+  $filename = sprintf($file_pattern, $name)
+  file { $filename:
+    content => template('network/interfaces.erb'),
+  }
+
+  if $restart {
+    File[$name] ~> Class['network::restart']
+  }
+}

--- a/manifests/interfaces.pp
+++ b/manifests/interfaces.pp
@@ -1,13 +1,14 @@
-class network::interfaces($interfaces={}, $mappings={}, $auto=[]) {
-
-  file { '/etc/network/interfaces':
-    content => template('network/interfaces.erb'),
-    notify  => Exec['network-restart'],
+class network::interfaces(
+  $interfaces={},
+  $mappings={},
+  $auto=[],
+  $restart=true,
+) {
+  network::interface_file { '/etc/network/interfaces':
+    interfaces => $interfaces,
+    mappings   => $mappings,
+    auto       => $auto,
+    restart    => $restart,
   }
 
-  exec { 'network-restart':
-      command     => '/etc/init.d/networking restart',
-      path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-      refreshonly => true,
-  }
 }

--- a/manifests/restart.pp
+++ b/manifests/restart.pp
@@ -1,0 +1,8 @@
+class network::restart {
+  exec { 'network-restart':
+      command     => '/etc/init.d/networking restart',
+      path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+      refreshonly => true,
+  }
+}
+


### PR DESCRIPTION
This moves the interface file generation into a defined type so that it
can be generically reusable.  For example, this can be used to generate
interface files centrally and distribute them at install time.  The
existing network::interfaces class can still be used and wraps the
defined type.
