### PR TITLE
"/etc/init.d/networking restart" is deprecated

### DIFF
--- a/manifests/restart.pp
+++ b/manifests/restart.pp
@@ -1,6 +1,6 @@
 class network::restart {
   exec { 'network-restart':
-      command     => '/etc/init.d/networking restart',
+      command     => 'ifdown --exclude=lo -a ; ifup --exclude=lo -a',
       path        => '/bin:/usr/bin:/sbin:/usr/sbin',
       refreshonly => true,
   }


### PR DESCRIPTION
"/etc/init.d/networking restart" has been deprecated for a long time. Ubuntu 14.04 now gives a cryptic error when trying to use it. See https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1301015

This fix is from https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1301015/comments/8 and should work on all distros
